### PR TITLE
fixed a bug in ldm/pixart/blocks.py

### DIFF
--- a/comfy/ldm/pixart/blocks.py
+++ b/comfy/ldm/pixart/blocks.py
@@ -12,7 +12,7 @@ from comfy.ldm.modules.attention import optimized_attention
 
 if model_management.xformers_enabled():
     import xformers.ops
-    if int((xformers.__version__).split(".")[2]) >= 28:
+    if int((xformers.__version__).split(".")[2].split("+")[0]) >= 28:
         block_diagonal_mask_from_seqlens = xformers.ops.fmha.attn_bias.BlockDiagonalMask.from_seqlens
     else:
         block_diagonal_mask_from_seqlens = xformers.ops.fmha.BlockDiagonalMask.from_seqlens


### PR DESCRIPTION
in the url[https://download.pytorch.org/whl/xformers/]
![image](https://github.com/user-attachments/assets/add0979f-1593-4859-8b5f-c813a79d3c1b)
The xformers lib version like this.
so should add another split method to fix it.
